### PR TITLE
Use UUID as a plugin name

### DIFF
--- a/CustomChatButton/.gitignore
+++ b/CustomChatButton/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomChatButton/configs/federationConfig.js
+++ b/CustomChatButton/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomChatButton": "./src/components/CustomChatButton",

--- a/CustomChatButton/package-lock.json
+++ b/CustomChatButton/package-lock.json
@@ -42,6 +42,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4289,6 +4290,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16473,6 +16481,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomChatButton/package.json
+++ b/CustomChatButton/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -46,6 +47,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomChatButton/scripts/add_metadata.js
+++ b/CustomChatButton/scripts/add_metadata.js
@@ -1,11 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
+  type: "CustomChatButton",
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomChatButton/scripts/set_uuid.js
+++ b/CustomChatButton/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomChatButton/webpack.config.js
+++ b/CustomChatButton/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomEntryPanel/.gitignore
+++ b/CustomEntryPanel/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomEntryPanel/configs/federationConfig.js
+++ b/CustomEntryPanel/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.UUID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomEntryPanel": "./src/components/CustomEntryPanel",

--- a/CustomEntryPanel/configs/federationConfig.js
+++ b/CustomEntryPanel/configs/federationConfig.js
@@ -2,7 +2,7 @@ const dependencies = require("../package.json").dependencies;
 const process = require("process");
 
 module.exports = {
-  name: process.env.UUID,
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomEntryPanel": "./src/components/CustomEntryPanel",

--- a/CustomEntryPanel/package-lock.json
+++ b/CustomEntryPanel/package-lock.json
@@ -42,6 +42,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4292,6 +4293,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16453,6 +16461,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomEntryPanel/package.json
+++ b/CustomEntryPanel/package.json
@@ -6,7 +6,7 @@
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
     "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js && node ./scripts/archive_dist.js",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $UUID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -46,6 +47,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomEntryPanel/package.json
+++ b/CustomEntryPanel/package.json
@@ -6,7 +6,7 @@
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
     "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",

--- a/CustomEntryPanel/package.json
+++ b/CustomEntryPanel/package.json
@@ -6,7 +6,7 @@
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
     "dev": "npm-run-all --parallel start serve",
-    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $UUID && node ./scripts/archive_dist.js",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",

--- a/CustomEntryPanel/package.json
+++ b/CustomEntryPanel/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
     "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",

--- a/CustomEntryPanel/scripts/add_metadata.js
+++ b/CustomEntryPanel/scripts/add_metadata.js
@@ -3,13 +3,13 @@ const fs = require("fs");
 const { name, version, description } = require("../package.json");
 const process = require("process");
 
-const uuid = process.argv[2];
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
   type: "CustomEntryPanel",
-  uuid,
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomEntryPanel/scripts/add_metadata.js
+++ b/CustomEntryPanel/scripts/add_metadata.js
@@ -1,12 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const uuid = process.argv[2];
 const metadata = {
   name,
   version,
   description,
   type: "CustomEntryPanel",
+  uuid,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomEntryPanel/scripts/add_metadata.js
+++ b/CustomEntryPanel/scripts/add_metadata.js
@@ -6,6 +6,7 @@ const metadata = {
   name,
   version,
   description,
+  type: "CustomEntryPanel",
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomEntryPanel/scripts/archive_dist.js
+++ b/CustomEntryPanel/scripts/archive_dist.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const AdmZip = require("adm-zip");
+
+const directoryPath = path.resolve(__dirname, "../", "dist");
+
+const zip = new AdmZip();
+zip.addLocalFolder(directoryPath);
+
+const filePath = path.join(directoryPath, "plugin.zip");
+zip.writeZip(filePath);

--- a/CustomEntryPanel/scripts/set_uuid.js
+++ b/CustomEntryPanel/scripts/set_uuid.js
@@ -1,0 +1,3 @@
+const { v4: uuidv4 } = require("uuid");
+
+console.log(`UUID=${uuidv4()}`);

--- a/CustomEntryPanel/scripts/set_uuid.js
+++ b/CustomEntryPanel/scripts/set_uuid.js
@@ -1,3 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 
-console.log(`UUID=${uuidv4()}`);
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomEntryPanel/webpack.config.js
+++ b/CustomEntryPanel/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.UUID": JSON.stringify(process.env.UUID),
     }),
   ],
   resolve: {

--- a/CustomEntryPanel/webpack.config.js
+++ b/CustomEntryPanel/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = {
       ignoreOrder: true,
     }),
     new webpack.DefinePlugin({
-      "process.env.UUID": JSON.stringify(process.env.UUID),
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomLeaveButton/.gitignore
+++ b/CustomLeaveButton/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomLeaveButton/configs/federationConfig.js
+++ b/CustomLeaveButton/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomLeaveButton": "./src/components/CustomLeaveButton",

--- a/CustomLeaveButton/package-lock.json
+++ b/CustomLeaveButton/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-modal": "^3.16.3",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
+        "adm-zip": "^0.5.16",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
@@ -42,6 +43,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4292,6 +4294,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
@@ -4834,9 +4843,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16473,6 +16482,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomLeaveButton/package.json
+++ b/CustomLeaveButton/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -30,6 +31,7 @@
     "@types/react-modal": "^3.16.3",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
+    "adm-zip": "^0.5.16",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
@@ -46,6 +48,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomLeaveButton/scripts/add_metadata.js
+++ b/CustomLeaveButton/scripts/add_metadata.js
@@ -1,11 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
+  type: "CustomLeaveButton",
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomLeaveButton/scripts/archive_dist.js
+++ b/CustomLeaveButton/scripts/archive_dist.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const AdmZip = require("adm-zip");
+
+const directoryPath = path.resolve(__dirname, "../", "dist");
+
+const zip = new AdmZip();
+zip.addLocalFolder(directoryPath);
+
+const filePath = path.join(directoryPath, "plugin.zip");
+zip.writeZip(filePath);

--- a/CustomLeaveButton/scripts/set_uuid.js
+++ b/CustomLeaveButton/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomLeaveButton/webpack.config.js
+++ b/CustomLeaveButton/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomOverlay/.gitignore
+++ b/CustomOverlay/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomOverlay/configs/federationConfig.js
+++ b/CustomOverlay/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomOverlay": "./src/components/CustomOverlay",

--- a/CustomOverlay/package-lock.json
+++ b/CustomOverlay/package-lock.json
@@ -41,6 +41,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4278,6 +4279,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16431,6 +16439,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomOverlay/package.json
+++ b/CustomOverlay/package.json
@@ -6,7 +6,7 @@
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
     "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js && node ./scripts/archive_dist.js",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -46,6 +47,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomOverlay/package.json
+++ b/CustomOverlay/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
     "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",

--- a/CustomOverlay/scripts/add_metadata.js
+++ b/CustomOverlay/scripts/add_metadata.js
@@ -1,12 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
   type: "CustomOverlay",
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomOverlay/scripts/set_uuid.js
+++ b/CustomOverlay/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomOverlay/webpack.config.js
+++ b/CustomOverlay/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomProfileModal/.gitignore
+++ b/CustomProfileModal/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomProfileModal/configs/federationConfig.js
+++ b/CustomProfileModal/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomProfileModal": "./src/components/CustomProfileModal",

--- a/CustomProfileModal/package-lock.json
+++ b/CustomProfileModal/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-modal": "^3.16.3",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
+        "adm-zip": "^0.5.16",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
@@ -42,6 +43,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4295,6 +4297,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
@@ -4837,9 +4846,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16476,6 +16485,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomProfileModal/package.json
+++ b/CustomProfileModal/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -30,6 +31,7 @@
     "@types/react-modal": "^3.16.3",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
+    "adm-zip": "^0.5.16",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
@@ -46,6 +48,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomProfileModal/scripts/add_metadata.js
+++ b/CustomProfileModal/scripts/add_metadata.js
@@ -1,11 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
+  type: "CustomProfileModal",
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomProfileModal/scripts/archive_dist.js
+++ b/CustomProfileModal/scripts/archive_dist.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const AdmZip = require("adm-zip");
+
+const directoryPath = path.resolve(__dirname, "../", "dist");
+
+const zip = new AdmZip();
+zip.addLocalFolder(directoryPath);
+
+const filePath = path.join(directoryPath, "plugin.zip");
+zip.writeZip(filePath);

--- a/CustomProfileModal/scripts/set_uuid.js
+++ b/CustomProfileModal/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomProfileModal/webpack.config.js
+++ b/CustomProfileModal/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomToolbarButton/.gitignore
+++ b/CustomToolbarButton/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomToolbarButton/configs/federationConfig.js
+++ b/CustomToolbarButton/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomToolbarButton": "./src/components/CustomToolbarButton",

--- a/CustomToolbarButton/package-lock.json
+++ b/CustomToolbarButton/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^16.9.24",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
+        "adm-zip": "^0.5.16",
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
         "eslint": "^8.57.0",
@@ -38,6 +39,7 @@
         "sass": "^1.77.8",
         "sass-loader": "^15.0.0",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -3005,6 +3007,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.11",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.11.tgz",
@@ -3524,9 +3533,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11596,6 +11605,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/CustomToolbarButton/package.json
+++ b/CustomToolbarButton/package.json
@@ -5,15 +5,16 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
     "lint:prettier": "prettier --check 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^16.9.24",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
+    "adm-zip": "^0.5.16",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
     "eslint": "^8.57.0",
@@ -37,6 +39,7 @@
     "sass": "^1.77.8",
     "sass-loader": "^15.0.0",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomToolbarButton/scripts/add_metadata.js
+++ b/CustomToolbarButton/scripts/add_metadata.js
@@ -10,7 +10,6 @@ const metadata = {
   description,
   type: "CustomToolbarButton",
   versionId,
-
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomToolbarButton/scripts/add_metadata.js
+++ b/CustomToolbarButton/scripts/add_metadata.js
@@ -1,11 +1,16 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
+  type: "CustomToolbarButton",
+  versionId,
+
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomToolbarButton/scripts/archive_dist.js
+++ b/CustomToolbarButton/scripts/archive_dist.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const AdmZip = require("adm-zip");
+
+const directoryPath = path.resolve(__dirname, "../", "dist");
+
+const zip = new AdmZip();
+zip.addLocalFolder(directoryPath);
+
+const filePath = path.join(directoryPath, "plugin.zip");
+zip.writeZip(filePath);

--- a/CustomToolbarButton/scripts/set_uuid.js
+++ b/CustomToolbarButton/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomToolbarButton/webpack.config.js
+++ b/CustomToolbarButton/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {

--- a/CustomWebCameraButton/.gitignore
+++ b/CustomWebCameraButton/.gitignore
@@ -25,3 +25,5 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+
+.uuid.env

--- a/CustomWebCameraButton/configs/federationConfig.js
+++ b/CustomWebCameraButton/configs/federationConfig.js
@@ -1,7 +1,8 @@
 const dependencies = require("../package.json").dependencies;
+const process = require("process");
 
 module.exports = {
-  name: "plugin",
+  name: process.env.VERSION_ID,
   filename: "remoteEntry.js",
   exposes: {
     "./CustomWebCameraButton": "./src/components/CustomWebCameraButton",

--- a/CustomWebCameraButton/package-lock.json
+++ b/CustomWebCameraButton/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^16.9.24",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
+        "adm-zip": "^0.5.16",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
@@ -41,6 +42,7 @@
         "sass-loader": "^15.0.0",
         "ts-jest": "^29.2.3",
         "typescript": "^5.5.4",
+        "uuidv4": "^6.2.13",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -4309,6 +4311,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
@@ -4851,9 +4860,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16479,6 +16488,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/CustomWebCameraButton/package.json
+++ b/CustomWebCameraButton/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "webpack --watch --mode development --config webpack.config.js",
     "serve": "webpack serve --mode development --config webpack.config.js",
-    "dev": "npm-run-all --parallel start serve",
-    "build": "webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js",
+    "dev": "npm run set-uuid && export $(cat .uuid.env) && npm-run-all --parallel start serve",
+    "build": "npm run set-uuid && export $(cat .uuid.env) && webpack --progress --mode production --config webpack.config.js && node ./scripts/add_metadata.js $VERSION_ID && node ./scripts/archive_dist.js",
     "test": "jest",
     "lint": "run-s -c lint:*",
     "lint:tsc": "tsc --noEmit",
@@ -14,7 +14,8 @@
     "lint:eslint": "eslint ./src",
     "lint-fix": "run-s -c lint-fix:*",
     "lint-fix:prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,scss}'",
-    "lint-fix:eslint": "eslint --fix ./src"
+    "lint-fix:eslint": "eslint --fix ./src",
+    "set-uuid": "node ./scripts/set_uuid.js > .uuid.env"
   },
   "devDependencies": {
     "@babel/core": "^7.24.9",
@@ -29,6 +30,7 @@
     "@types/react-dom": "^16.9.24",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
+    "adm-zip": "^0.5.16",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
@@ -45,6 +47,7 @@
     "sass-loader": "^15.0.0",
     "ts-jest": "^29.2.3",
     "typescript": "^5.5.4",
+    "uuidv4": "^6.2.13",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/CustomWebCameraButton/scripts/add_metadata.js
+++ b/CustomWebCameraButton/scripts/add_metadata.js
@@ -1,11 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const { name, version, description } = require("../package.json");
+const process = require("process");
 
+const versionId = process.argv[2];
 const metadata = {
   name,
   version,
   description,
+  type: "CustomWebCameraButton",
+  versionId,
 };
 const jsonData = JSON.stringify(metadata, null, 2);
 

--- a/CustomWebCameraButton/scripts/archive_dist.js
+++ b/CustomWebCameraButton/scripts/archive_dist.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const AdmZip = require("adm-zip");
+
+const directoryPath = path.resolve(__dirname, "../", "dist");
+
+const zip = new AdmZip();
+zip.addLocalFolder(directoryPath);
+
+const filePath = path.join(directoryPath, "plugin.zip");
+zip.writeZip(filePath);

--- a/CustomWebCameraButton/scripts/set_uuid.js
+++ b/CustomWebCameraButton/scripts/set_uuid.js
@@ -1,0 +1,6 @@
+const { v4: uuidv4 } = require("uuid");
+
+const uuid = uuidv4();
+const versionId = "app_" + uuid.replace(/-/g, "");
+
+console.log(`VERSION_ID=${versionId}`);

--- a/CustomWebCameraButton/webpack.config.js
+++ b/CustomWebCameraButton/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+const process = require("process");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin =
@@ -86,6 +88,10 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "assets/stylesheets/[name]-[contenthash].css",
       ignoreOrder: true,
+    }),
+
+    new webpack.DefinePlugin({
+      "process.env.VERSION_ID": JSON.stringify(process.env.VERSION_ID),
     }),
   ],
   resolve: {


### PR DESCRIPTION
## 概要

pluginの名前としてクライアントで生成したUUIDを使用するようにする。
UUIDの形式を直接使用するとエラーになるため、prefixに`app_`を付与し、`-` は削除するようにした。

## Progress

- [x] CustomChatButton
- [x] CustomEntryPanel
- [x] CustomLeaveButton
- [x] CustomOverlay
- [x] CustomProfileModal
- [x] CustomToolbarButton
- [x] CustomWebCameraButton
