### PR TITLE
CustomExitScreen の dev サーバのポートを 3004 に統一

### DIFF
--- a/CustomExitScreen/README.md
+++ b/CustomExitScreen/README.md
@@ -13,7 +13,7 @@ npm install
 npm run dev
 ```
 
-The dev server runs at `http://localhost:5173`.
+The dev server runs at `http://localhost:3004`.
 
 ## Build
 

--- a/CustomExitScreen/vite.config.ts
+++ b/CustomExitScreen/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: true
   },
   server: {
-    port: 5173,
+    port: 3004,
     strictPort: true,
     headers: {
       "Access-Control-Allow-Origin": "*"


### PR DESCRIPTION
## 概要

CustomExitScreen だけ dev サーバが 5173 で、他10テンプレートは 3004 でした。3004 に揃えます。

## 背景

ルート README はローカルプラグインの読み込み手順を **3004 前提**で書いています。

```js
entry: "http://localhost:3004/remoteEntry.js"
```

> We assume that local plugin is running on `http://localhost:3004`.

このため CustomExitScreen だけは、ローカルで metatell_client から読み込む際にポートを手で読み替える必要がありました。

## 変更

- `CustomExitScreen/vite.config.ts` — `port: 5173` → `port: 3004`
- `CustomExitScreen/README.md` — 記載を 3004 に更新

`strictPort: true` は元から設定済みなので、ポートが埋まっている場合は黙って別ポートに移らずエラーになります。

## 動作確認

- dev サーバが `http://localhost:3004/` で起動し、プレビュー画面が正常に描画されることをブラウザで確認
- build ✅ / lint ✅
- 全11テンプレートが `port: 3004` に揃ったことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)